### PR TITLE
Another attempt at Handlers

### DIFF
--- a/src/com/google/gwt/sample/showcase/client/Handlers.scala
+++ b/src/com/google/gwt/sample/showcase/client/Handlers.scala
@@ -16,36 +16,116 @@ package com.google.gwt.sample.showcase.client
  * the License.
  */
 
-import com.google.gwt.event.dom.client.ChangeEvent
-import com.google.gwt.event.dom.client.ChangeHandler
-import com.google.gwt.event.dom.client.ClickEvent
-import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.event.logical.shared._
+import com.google.gwt.event.dom.client._
 
 /**
  * Provides implicit conversions that allow functions to be substituted where handlers are called for.
  */
-object Handlers {
-   implicit def fn2changeHandler(fn: ChangeEvent => Unit): ChangeHandler =
-      new ChangeHandler() {
-         def onChange(event: ChangeEvent) = fn(event)
-      }
-   implicit def fn2clickHandler(fn: ClickEvent => Unit): ClickHandler =
-      new ClickHandler() {
-         def onClick(event: ClickEvent) = fn(event)
-      }
-   implicit def fn2selectionHandler[T](fn: SelectionEvent[T] => Unit): SelectionHandler[T] =
-      new SelectionHandler[T] {
-         def onSelection(event: SelectionEvent[T]): Unit = fn(event)
-      }
-   implicit def fn2valueChangeHandler[T](fn: ValueChangeEvent[T] => Unit): ValueChangeHandler[T] =
-      new ValueChangeHandler[T] {
-         def onValueChange(event: ValueChangeEvent[T]): Unit = fn(event)
-      }
-   implicit def fn2openHandler[T](fn: OpenEvent[T] => Unit): OpenHandler[T] =
-      new OpenHandler[T] {
-         def onOpen(event: OpenEvent[T]): Unit = fn(event)
-      }
+object Handlers extends ChangeHandlers
+  with ClickHandlers
+  with KeyUpHandlers
+  with KeyDownHandlers
+  with SelectionHandlers
+  with ValueChangeHandlers
+  with OpenHandlers
+
+trait ChangeHandlers {
+  implicit def fn2changeHandler(fn: ChangeEvent => Unit): ChangeHandler =
+    new ChangeHandler() {
+      def onChange(event: ChangeEvent) = fn(event)
+    }
+  implicit def enrichHasChangeHandlers(o: HasChangeHandlers): RichHasChangeHandlers =
+    new RichHasChangeHandlers(o)
+
+  class RichHasChangeHandlers(o: HasChangeHandlers) {
+    def onChange(fn: ChangeEvent => Unit) = o.addChangeHandler(fn)
+  }
 }
+object ChangeHandlers extends ChangeHandlers
+
+trait ClickHandlers {
+  implicit def fn2clickHandler(fn: ClickEvent => Unit): ClickHandler =
+    new ClickHandler() {
+      def onClick(event: ClickEvent) = fn(event)
+    }
+  implicit def enrichHasClickHandlers(o: HasClickHandlers): RichHasClickHandlers =
+    new RichHasClickHandlers(o)
+
+  class RichHasClickHandlers(o: HasClickHandlers) {
+    def onClick(fn: ClickEvent => Unit) = o.addClickHandler(fn)
+  }
+}
+object ClickHandlers extends ClickHandlers
+
+trait KeyUpHandlers {
+  implicit def fn2keyUpHandler(fn: KeyUpEvent => Unit): KeyUpHandler =
+    new KeyUpHandler {
+      def onKeyUp(event: KeyUpEvent) = fn(event)
+    }
+  implicit def enrichHasKeyUpHandlers(o: HasKeyUpHandlers): RichHasKeyUpHandlers =
+    new RichHasKeyUpHandlers(o)
+
+  class RichHasKeyUpHandlers(o: HasKeyUpHandlers) {
+    def onKeyUp(fn: KeyUpEvent => Unit) = o.addKeyUpHandler(fn)
+  }
+}
+object KeyUpHandlers extends KeyUpHandlers
+
+trait KeyDownHandlers {
+  implicit def fn2keyDownHandler(fn: KeyDownEvent => Unit): KeyDownHandler =
+    new KeyDownHandler {
+      def onKeyDown(event: KeyDownEvent) = fn(event)
+    }
+  implicit def enrichHasKeyDownHandlers(o: HasKeyDownHandlers): RichHasKeyDownHandlers =
+    new RichHasKeyDownHandlers(o)
+
+  class RichHasKeyDownHandlers(o: HasKeyDownHandlers) {
+    def onKeyDown(fn: KeyDownEvent => Unit) = o.addKeyDownHandler(fn)
+  }
+}
+object KeyDownHandlers extends KeyDownHandlers
+
+trait SelectionHandlers {
+  implicit def fn2selectionHandler[T](fn: SelectionEvent[T] => Unit): SelectionHandler[T] =
+    new SelectionHandler[T] {
+      def onSelection(event: SelectionEvent[T]): Unit = fn(event)
+    }
+  implicit def enrichHasSelectionHandlers[T](o: HasSelectionHandlers[T]): RichHasSelectionHandlers[T] =
+    new RichHasSelectionHandlers[T](o)
+
+  class RichHasSelectionHandlers[T](o: HasSelectionHandlers[T]) {
+    def onSelection(fn: SelectionEvent[T] => Unit) = o.addSelectionHandler(fn)
+  }
+}
+object SelectionHandlers extends SelectionHandlers
+
+trait ValueChangeHandlers {
+  implicit def fn2valueChangeHandler[T](fn: ValueChangeEvent[T] => Unit): ValueChangeHandler[T] =
+    new ValueChangeHandler[T] {
+      def onValueChange(event: ValueChangeEvent[T]): Unit = fn(event)
+    }
+  implicit def enrichHasValueChangeHandlers[T](o: HasValueChangeHandlers[T]): RichHasValueChangeHandlers[T] =
+    new RichHasValueChangeHandlers[T](o)
+
+  class RichHasValueChangeHandlers[T](o: HasValueChangeHandlers[T]) {
+    def onValueChange(fn: ValueChangeEvent[T] => Unit) = o.addValueChangeHandler(fn)
+  }
+}
+object ValueChangeHandlers extends ValueChangeHandlers
+
+trait OpenHandlers {
+  implicit def fn2openHandler[T](fn: OpenEvent[T] => Unit): OpenHandler[T] =
+    new OpenHandler[T] {
+      def onOpen(event: OpenEvent[T]): Unit = fn(event)
+    }
+  implicit def enrichHasOpenHandlers[T](o: HasOpenHandlers[T]): RichHasOpenHandlers[T] =
+    new RichHasOpenHandlers[T](o)
+
+  class RichHasOpenHandlers[T](o: HasOpenHandlers[T]) {
+    def onOpen(fn: OpenEvent[T] => Unit) = o.addOpenHandler(fn)
+  }
+}
+object OpenHandlers extends OpenHandlers
 
 

--- a/src/com/google/gwt/sample/showcase/client/Showcase.scala
+++ b/src/com/google/gwt/sample/showcase/client/Showcase.scala
@@ -183,7 +183,7 @@ class Showcase extends EntryPoint {
       setupMainMenu(constants)
 
       // Setup a history handler to reselect the associate menu item
-      History.addValueChangeHandler { event: ValueChangeEvent[String] =>
+      History addValueChangeHandler { event: ValueChangeEvent[String] =>
          var item: TreeItem = itemTokens.get(event.getValue)
          if (item == null) {
             item = app.getMainMenu.getItem(0).getChild(0)
@@ -194,7 +194,7 @@ class Showcase extends EntryPoint {
       }
 
       // Add a handler that sets the content widget when a menu item is selected
-      app.addSelectionHandler { event: SelectionEvent[TreeItem] =>
+      app onSelection { event =>
          var item = event.getSelectedItem
          var content: ContentWidget = itemWidgets.get(item)
          if (content != null && !content.equals(app.getContent)) {
@@ -381,7 +381,7 @@ class Showcase extends EntryPoint {
             }
          }
       }
-      localeBox.addChangeHandler { event: ChangeEvent =>
+      localeBox onChange { _ =>
          val localeName = localeBox.getValue(localeBox.getSelectedIndex)
          val builder = Location.createUrlBuilder.setParameter("locale", localeName)
          Window.Location.replace(builder.buildString)
@@ -398,7 +398,7 @@ class Showcase extends EntryPoint {
       ShowcaseConstants.STYLE_THEMES foreach { theme =>
          val button: ThemeButton = new ThemeButton(theme)
          styleWrapper.add(button)
-         button.addClickHandler { event: ClickEvent =>
+         button onClick { _ =>
             // Update the current theme
             CUR_THEME = button.theme
 

--- a/src/com/google/gwt/sample/showcase/client/content/i18n/CwConstantsExample.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/i18n/CwConstantsExample.scala
@@ -22,6 +22,7 @@ import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.event.logical.shared.SelectionEvent
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.JavaConversions._
 import com.google.gwt.sample.showcase.client.ShowcaseConstants
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
@@ -100,11 +101,7 @@ class CwConstantsExample(constants: CwConstantsExample.CwConstants) extends Cont
     // Add a link to the source code of the Interface
     val link = new HTML(
         " <a href=\"javascript:void(0);\">ExampleConstants</a>")
-    link.addClickHandler(new ClickHandler() {
-      def onClick(event: ClickEvent) {
-        selectTab(2)
-      }
-    })
+    link onClick { _ => selectTab(2) }
     val linkPanel = new HorizontalPanel()
     linkPanel.setSpacing(3)
     linkPanel.add(new HTML(constants.cwConstantsExampleLinkText()))

--- a/src/com/google/gwt/sample/showcase/client/content/lists/CwListBox.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/lists/CwListBox.scala
@@ -100,7 +100,7 @@ class CwListBox(@ShowcaseData private val constants: CwListBox.CwConstants)
     hPanel.add(multiBoxPanel)
 
     // Add a handler to handle drop box events
-    dropBox.addChangeHandler { event: ChangeEvent =>
+    dropBox onChange { _ =>
       showCategory(multiBox, dropBox.getSelectedIndex)
       multiBox.ensureDebugId("cwListBox-multiBox")
     }

--- a/src/com/google/gwt/sample/showcase/client/content/lists/CwStackPanel.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/lists/CwStackPanel.scala
@@ -189,10 +189,10 @@ class CwStackPanel(@ShowcaseData private val constants: CwStackPanel.CwConstants
       val (contactName, contactEmail) = pair
       val contactLink: HTML =
         new HTML("""<a href="javascript:undefined;">""" + contactName + "</a>")
-        contactsPanel.add(contactLink)
+      contactsPanel.add(contactLink)
 
-        // Open the contact info popup when the user clicks a contact
-        contactLink.addClickHandler { event: ClickEvent =>
+      // Open the contact info popup when the user clicks a contact
+      contactLink onClick { _ =>
         // Set the info about the contact
         contactInfo.setHTML(contactName + "<br><i>" + contactEmail + "</i>")
 

--- a/src/com/google/gwt/sample/showcase/client/content/lists/CwTree.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/lists/CwTree.scala
@@ -181,7 +181,7 @@ class CwTree(@ShowcaseData private val constants: CwTree.CwConstants)
     }
 
     // Add a handler that automatically generates some children
-    dynamicTree.addOpenHandler { event: OpenEvent[TreeItem] =>
+    dynamicTree onOpen { event =>
       val item = event.getTarget
       if (item.getChildCount == 1) {
         // Close the item immediately

--- a/src/com/google/gwt/sample/showcase/client/content/other/CwAnimation.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/other/CwAnimation.scala
@@ -23,6 +23,7 @@ import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.i18n.client.Constants.DefaultStringValue
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.Showcase
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
@@ -245,17 +246,13 @@ class CwAnimation(constants: CwAnimation.CwConstants) extends ContentWidget(cons
     // Add start button
     startButton = new Button(constants.cwAnimationStart)
     startButton.addStyleName("sc-FixedWidthButton")
-    startButton.addClickHandler(new ClickHandler() {
-      def onClick(event:ClickEvent) = animation.run(2000)
-    })
+    startButton onClick { _ => animation.run(2000) }
     optionsBar.add(startButton)
 
     // Add cancel button
     cancelButton = new Button(constants.cwAnimationCancel)
     cancelButton.addStyleName("sc-FixedWidthButton")
-    cancelButton.addClickHandler(new ClickHandler() {
-      def onClick(event: ClickEvent) = animation.cancel()
-    })
+    cancelButton onClick { _ => animation.cancel() }
     optionsBar.add(cancelButton)
 
     // Return the options bar

--- a/src/com/google/gwt/sample/showcase/client/content/other/CwCookies.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/other/CwCookies.scala
@@ -23,6 +23,7 @@ import com.google.gwt.event.dom.client.ClickEvent
 import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.JavaConversions._
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
@@ -129,42 +130,35 @@ class CwCookies(constants: CwCookies.CwConstants) extends ContentWidget(constant
     mainLayout.setWidget(2, 2, setCookieButton)
 
     // Add a handler to set the cookie value
-    setCookieButton.addClickHandler(new ClickHandler() {
-      def onClick(event: ClickEvent) {
-        val name = cookieNameBox.getText()
-        val value = cookieValueBox.getText()
-        val expires = new Date((new Date()).getTime() + COOKIE_TIMEOUT)
+    setCookieButton onClick { _ =>
+      val name = cookieNameBox.getText()
+      val value = cookieValueBox.getText()
+      val expires = new Date((new Date()).getTime() + COOKIE_TIMEOUT)
 
-        // Verify the name is valid
-        if (name.length() < 1) {
-          Window.alert(constants.cwCookiesInvalidCookie())
-          return
-        }
-
+      // Verify the name is valid
+      if (name.length() < 1) {
+        Window.alert(constants.cwCookiesInvalidCookie())
+      } else {
         // Set the cookie value
         Cookies.setCookie(name, value, expires)
         refreshExistingCookies(name)
       }
-    })
+    }
 
     // Add a handler to select an existing cookie
-    existingCookiesBox.addChangeHandler(new ChangeHandler() {
-      def onChange(event: ChangeEvent) = updateExstingCookie()
-    })
+    existingCookiesBox onChange { _ => updateExstingCookie() }
 
     // Add a handler to delete an existing cookie
-    deleteCookieButton.addClickHandler(new ClickHandler() {
-      def onClick(event: ClickEvent) {
-        val selectedIndex = existingCookiesBox.getSelectedIndex()
-        if (selectedIndex > -1
-            && selectedIndex < existingCookiesBox.getItemCount()) {
-          val cookieName = existingCookiesBox.getValue(selectedIndex)
-          Cookies.removeCookie(cookieName)
-          existingCookiesBox.removeItem(selectedIndex)
-          updateExstingCookie()
-        }
+    deleteCookieButton onClick { _ =>
+      val selectedIndex = existingCookiesBox.getSelectedIndex()
+      if (selectedIndex > -1
+          && selectedIndex < existingCookiesBox.getItemCount()) {
+        val cookieName = existingCookiesBox.getValue(selectedIndex)
+        Cookies.removeCookie(cookieName)
+        existingCookiesBox.removeItem(selectedIndex)
+        updateExstingCookie()
       }
-    })
+    }
 
     // Return the main layout
     refreshExistingCookies(null)

--- a/src/com/google/gwt/sample/showcase/client/content/other/CwFrame.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/other/CwFrame.scala
@@ -24,6 +24,7 @@ import com.google.gwt.event.dom.client.KeyDownEvent
 import com.google.gwt.event.dom.client.KeyDownHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
 import com.google.gwt.user.client.rpc.AsyncCallback
@@ -80,18 +81,14 @@ class CwFrame(constants: CwFrame.CwConstants) extends ContentWidget(constants) {
     optionsPanel.add(setLocationButton)
 
     // Change the location when the user clicks the button
-    setLocationButton.addClickHandler(new ClickHandler() {
-      def onClick(event: ClickEvent) = frame.setUrl(locationBox.getText)
-    })
+    setLocationButton onClick { _ => frame.setUrl(locationBox.getText) }
 
     // Change the location when the user presses enter
-    locationBox.addKeyDownHandler(new KeyDownHandler() {
-      def onKeyDown(event: KeyDownEvent) {
-        if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
-          frame.setUrl(locationBox.getText)
-        }
+    locationBox onKeyDown { event =>
+      if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
+        frame.setUrl(locationBox.getText)
       }
-    })
+    }
 
     // Add everything to a panel and return it
     val vPanel = new VerticalPanel()

--- a/src/com/google/gwt/sample/showcase/client/content/popups/CwBasicPopup.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/popups/CwBasicPopup.scala
@@ -21,6 +21,7 @@ import com.google.gwt.event.dom.client.ClickEvent
 import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.Showcase
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
@@ -79,18 +80,16 @@ class CwBasicPopup(constants: CwBasicPopup.CwConstants) extends ContentWidget(co
 
     // Create a button to show the popup
     val openButton = new Button(constants.cwBasicPopupShowButton,
-        new ClickHandler() {
-          def onClick(event: ClickEvent) {
-            // Reposition the popup relative to the button
-            val source = event.getSource.asInstanceOf[Widget]
-            val left = source.getAbsoluteLeft + 10
-            val top = source.getAbsoluteTop + 10
-            simplePopup.setPopupPosition(left, top)
+      { event: ClickEvent =>
+          // Reposition the popup relative to the button
+          val source = event.getSource.asInstanceOf[Widget]
+          val left = source.getAbsoluteLeft + 10
+          val top = source.getAbsoluteTop + 10
+          simplePopup.setPopupPosition(left, top)
 
-            // Show the popup
-            simplePopup.show()
-          }
-        })
+          // Show the popup
+          simplePopup.show()
+      })
 
     // Create a popup to show the full size image
     val jimmyFull = new Image(Showcase.images.jimmy)
@@ -98,17 +97,13 @@ class CwBasicPopup(constants: CwBasicPopup.CwConstants) extends ContentWidget(co
     imagePopup.setAnimationEnabled(true)
     imagePopup.ensureDebugId("cwBasicPopup-imagePopup")
     imagePopup.setWidget(jimmyFull)
-    jimmyFull.addClickHandler(new ClickHandler() {
-      def onClick(event: ClickEvent) = imagePopup.hide()
-    })
+    jimmyFull onClick { _ => imagePopup.hide() }
 
     // Add an image thumbnail
     val jimmyThumb = new Image(Showcase.images.jimmyThumb)
     jimmyThumb.ensureDebugId("cwBasicPopup-thumb")
     jimmyThumb.addStyleName("cw-BasicPopup-thumb")
-    jimmyThumb.addClickHandler(new ClickHandler() {
-      def onClick(event: ClickEvent) = imagePopup.center()
-    })
+    jimmyThumb onClick { _ => imagePopup.center() }
 
     // Add the widgets to a panel
     val vPanel = new VerticalPanel()

--- a/src/com/google/gwt/sample/showcase/client/content/popups/CwDialogBox.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/popups/CwDialogBox.scala
@@ -22,6 +22,7 @@ import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.i18n.client.LocaleInfo
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.Showcase
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
@@ -86,12 +87,10 @@ class CwDialogBox(constants: CwDialogBox.CwConstants) extends ContentWidget(cons
 
     // Create a button to show the dialog Box
     val openButton = new Button(constants.cwDialogBoxShowButton,
-        new ClickHandler() {
-          def onClick(sender: ClickEvent) {
-            dialogBox.center()
-            dialogBox.show()
-          }
-        })
+      { _: ClickEvent =>
+          dialogBox.center()
+          dialogBox.show()
+      })
 
     // Create a ListBox
     val listDesc = new HTML("<br><br><br>" + constants.cwDialogBoxListBoxInfo)
@@ -152,9 +151,7 @@ class CwDialogBox(constants: CwDialogBox.CwConstants) extends ContentWidget(cons
 
     // Add a close button at the bottom of the dialog
     val closeButton = new Button(constants.cwDialogBoxClose,
-        new ClickHandler() {
-          def onClick(event: ClickEvent) = dialogBox.hide()
-        })
+                                 (_: ClickEvent) => dialogBox.hide())
     dialogContents.add(closeButton)
     if (LocaleInfo.getCurrentLocale().isRTL()) {
       dialogContents.setCellHorizontalAlignment(closeButton,

--- a/src/com/google/gwt/sample/showcase/client/content/tables/CwFlexTable.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/tables/CwFlexTable.scala
@@ -21,6 +21,7 @@ import com.google.gwt.event.dom.client.ClickEvent
 import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.Showcase
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
@@ -82,15 +83,11 @@ class CwFlexTable(constants: CwFlexTable.CwConstants) extends ContentWidget(cons
 
     // Add a button that will add more rows to the table
     val addRowButton = new Button(constants.cwFlexTableAddRow(),
-        new ClickHandler() {
-          def onClick(event: ClickEvent) = addRow(flexTable)
-        })
+                                  (_: ClickEvent) => addRow(flexTable))
     addRowButton.addStyleName("sc-FixedWidthButton")
 
     val removeRowButton = new Button(constants.cwFlexTableRemoveRow(),
-        new ClickHandler() {
-          def onClick(event: ClickEvent) = removeRow(flexTable)
-        })
+                                     (_: ClickEvent) => removeRow(flexTable))
     removeRowButton.addStyleName("sc-FixedWidthButton")
     val buttonPanel = new VerticalPanel()
     buttonPanel.setStyleName("cw-FlexTable-buttonPanel")

--- a/src/com/google/gwt/sample/showcase/client/content/text/CwBasicText.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/text/CwBasicText.scala
@@ -23,6 +23,7 @@ import com.google.gwt.event.dom.client.KeyUpEvent
 import com.google.gwt.event.dom.client.KeyUpHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseStyle
@@ -141,18 +142,10 @@ class CwBasicText(constants: CwBasicText.CwConstants) extends ContentWidget(cons
       val label = new Label(constants.cwBasicTextSelected() + ": 0, 0")
 
       // Add a KeyUpHandler
-      textBox.addKeyUpHandler(new KeyUpHandler() {
-        def onKeyUp(event: KeyUpEvent) = {
-          updateSelectionLabel(textBox, label)
-        }
-      })
+      textBox onKeyUp { _ => updateSelectionLabel(textBox, label) }
 
       // Add a ClickHandler
-      textBox.addClickHandler(new ClickHandler() {
-        def onClick(event: ClickEvent) = {
-          updateSelectionLabel(textBox, label)
-        }
-      })
+      textBox onClick { _ => updateSelectionLabel(textBox, label) }
 
       // Add the label to the box
       hPanel.add(label)

--- a/src/com/google/gwt/sample/showcase/client/content/widgets/CwBasicButton.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/widgets/CwBasicButton.scala
@@ -21,6 +21,7 @@ import com.google.gwt.event.dom.client.ClickEvent
 import com.google.gwt.event.dom.client.ClickHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseStyle
@@ -70,9 +71,7 @@ class CwBasicButton(constants: CwBasicButton.CwConstants) extends ContentWidget(
     // Add a normal button
     val normalButton = new Button(
         constants.cwBasicButtonNormal,
-        new ClickHandler() {
-          def onClick(event: ClickEvent) = Window.alert(constants.cwBasicButtonClickMessage)
-        })
+        (_: ClickEvent) => Window.alert(constants.cwBasicButtonClickMessage))
     normalButton.ensureDebugId("cwBasicButton-normal")
     hPanel.add(normalButton)
 

--- a/src/com/google/gwt/sample/showcase/client/content/widgets/CwDatePicker.scala
+++ b/src/com/google/gwt/sample/showcase/client/content/widgets/CwDatePicker.scala
@@ -22,6 +22,7 @@ import com.google.gwt.event.logical.shared.ValueChangeHandler
 import com.google.gwt.i18n.client.Constants
 import com.google.gwt.i18n.client.DateTimeFormat
 import com.google.gwt.sample.showcase.client.ContentWidget
+import com.google.gwt.sample.showcase.client.Handlers._
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseData
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseSource
 import com.google.gwt.sample.showcase.client.ShowcaseAnnotations.ShowcaseStyle
@@ -71,13 +72,11 @@ class CwDatePicker(constants: CwDatePicker.CwConstants) extends ContentWidget(co
     val text = new Label()
 
     // Set the value in the text box when the user selects a date
-    datePicker.addValueChangeHandler(new ValueChangeHandler[Date]() {
-      def onValueChange(event: ValueChangeEvent[Date]) {
-        val date = event.getValue()
-        val dateString = DateTimeFormat.getMediumDateFormat().format(date)
-        text.setText(dateString)
-      }
-    })
+    datePicker onValueChange { event =>
+      val date = event.getValue()
+      val dateString = DateTimeFormat.getMediumDateFormat().format(date)
+      text.setText(dateString)
+    }
 
     // Set the default value
     datePicker.setValue(new Date(), true)


### PR DESCRIPTION
Compare to #5.  This version removes the convenience methods for the "ignored event" use case. 

`button onClick { Window.alert("Click!") }` becomes `button onClick { _ => Window.alert("Click!") }`

`new Button("Do it", () => Window.alert("Click!"))` becomes `new Button("Do it", (_: ClickEvent) => Window.alert("Click!"))`
