### PR TITLE
Work-around for Scala compiler bug.

### DIFF
--- a/src/com/google/gwt/sample/showcase/client/ContentWidget.scala
+++ b/src/com/google/gwt/sample/showcase/client/ContentWidget.scala
@@ -78,7 +78,7 @@ object ContentWidget {
  * <li>.sc-ContentWidget-description { Applied to the description }</li>
  * </ul>
  */
-abstract class ContentWidget(constants: ContentWidget.CwConstants) extends LazyPanel with SelectionHandler[Integer] {
+abstract class ContentWidget(constants: ContentWidget.CwConstants) extends LazyPanel with SelectionHandler[java.lang.Integer] {
 
   /**
    * The default style name.
@@ -197,7 +197,7 @@ abstract class ContentWidget(constants: ContentWidget.CwConstants) extends LazyP
   def onInitializeComplete(): Unit = {
   }
 
-  def onSelection(event: SelectionEvent[Integer]): Unit = {
+  def onSelection(event: SelectionEvent[java.lang.Integer]): Unit = {
     // Show the associated widget in the deck panel
     val tabIndex = event.getSelectedItem().intValue()
     deckPanel.showWidget(tabIndex)


### PR DESCRIPTION
Latest Scala compiler seems to be confused if
we use just `Integer` to refer to java.lang.Integer.

That confusion results in broken output files
(it goes through type checker!) which is bad. Using
fully qualified name is enough to work-aroudn this
issue. Nailing it down would be better but those
things tend to take days to address so I won't
bother at the moment.

Change-Id: Ibd0e6d791277093e5c451a9249bd189818fbf87f
Signed-off-by: Grzegorz Kossakowski grzegorz.kossakowski@gmail.com
