### PR TITLE
Work-around in gwtdlx sample.

### DIFF
--- a/src/com/google/gwt/sample/gwtdlx/client/GwtDlx.scala
+++ b/src/com/google/gwt/sample/gwtdlx/client/GwtDlx.scala
@@ -116,18 +116,19 @@ class GwtDlx extends EntryPoint {
       sched {
          val result = (Sudoku(board)).solve
          ajax.setVisible(false)
-         result match {
-            case None => noSolution.setVisible(true)
-            case Some(soln) => {
-               noSolution.setVisible(false)
-               for (r <- 0 until soln.length) {
-                  for (c <- 0 until soln(r).length) {
-                     getBox(r, c).setValue(soln(r)(c) + "")
-                  }
-               }
-               ajax.setVisible(false)
-            }
-         }
+         //TODO(grek): Changed pattern patch on Option to if due to collision
+         //between Yvirtpatmat and CPS plugin. Changed back once it's fixed upstream.
+         if (result.isDefined) {
+           val soln = result.get
+           noSolution.setVisible(false)
+           for (r <- 0 until soln.length) {
+              for (c <- 0 until soln(r).length) {
+                 getBox(r, c).setValue(soln(r)(c) + "")
+              }
+           }
+           ajax.setVisible(false)
+         } else
+            noSolution.setVisible(true)
       }
    }
 }


### PR DESCRIPTION
Virtual pattern matcher doesn't play nicely with
continuations at the moment so I had to get rid of
one pattern used in context where CPS transformation
is being applied. This should be reverted once
virtpatmat is fixed.
