### PR TITLE
Work-around for CPS and vpm problem

### DIFF
--- a/src/com/google/gwt/sample/gwtdlx/client/GwtDlx.scala
+++ b/src/com/google/gwt/sample/gwtdlx/client/GwtDlx.scala
@@ -128,6 +128,8 @@ class GwtDlx extends EntryPoint {
                ajax.setVisible(false)
             }
          }
+         //TODO(grek): Work-around for CPS-vpm interaction problem.
+         ()
       }
    }
 }


### PR DESCRIPTION
CPS and virtual pattern matcher do not mix
well yet so we needed to introduce this trivial
work-around.
